### PR TITLE
Fix installation command for libgirepository package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Linux (source)
 First, you will need to install some dependencies on your system. On Debian and
 Ubuntu this can be achieved with the following command::
 
-    sudo apt install git build-essential python3 python3-dev python3-pip libgirepository1.0-dev pkg-config gir1.2-gtk-3.0
+    sudo apt install git build-essential python3 python3-dev python3-pip libgirepository-2.0-dev pkg-config gir1.2-gtk-3.0
 
 Then clone this repository and navigate to it::
 


### PR DESCRIPTION
Updated the libgirepository requirement in installation instructions.

Use libgirepository-2.0-dev, like in the GitHub workflow definition.